### PR TITLE
(MAINT) Fix GHP deployment

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,8 @@ jobs:
         run: npm ci
       - name: Validate Resume Schema
         run: npm run validate
+      - name: Rename resume.html
+        run: mv public/resume.html public/index.html
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:


### PR DESCRIPTION
Prior to this change, the GitHub Pages deployment workflow was succeeding but publishing the resume to the incorrect URL:

```yaml
expected: https://michaeltlombardi.github.io/resume/
actual:   https://michaeltlombardi.github.io/resume/resume
```

This was caused by the export step being removed from the CI workflow, and `resumefy` exporting the resume as `resume.html` instead of `index.html`.

This change updates the publish workflow to rename `resume.html` to `index.html` before deploying to GitHub Pages, which should ensure that the resume is published to the correct URL.